### PR TITLE
Add IPPrefixLen to the list of exported network attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ NAMESPACE=Kaginari
 NAME=docker-utils
 VERSION=9.9.9
 ## on linux base os
-TERRAFORM_PLUGINS_DIRECTORY=/home/monta/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+TERRAFORM_PLUGINS_DIRECTORY=${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ TERRAFORM_PLUGINS_DIRECTORY=${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE
 install:
 	mkdir -p ${TERRAFORM_PLUGINS_DIRECTORY}
 	go build -o ${TERRAFORM_PLUGINS_DIRECTORY}/terraform-provider-${NAME}
-	cd examples && rm -rf .terraform
+	cd examples && rm -rf .terraform && rm -f .terraform.lock.hcl
 	cd examples && make init
 re-install:
 	rm -f ${TERRAFORM_PLUGINS_DIRECTORY}/terraform-provider-${NAME}
 	go build -o ${TERRAFORM_PLUGINS_DIRECTORY}/terraform-provider-${NAME}
-	cd examples && rm -rf .terraform
+	cd examples && rm -rf .terraform && rm -f .terraform.lock.hcl
 	cd examples && make init
 lint:
 	 golangci-lint run

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 This repository is docker-utils provider for [Terraform](https://www.terraform.io).
 
 ## Developer
+
 - Montassar bouajina (bouagina.montassar@gmail.com)
+
 ### Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 0.13
@@ -15,8 +17,8 @@ This repository is docker-utils provider for [Terraform](https://www.terraform.i
 1. Enter the repository directory
 1. Build the provider using the `make install` command:
 
-````bash
+```bash
 git clone https://github.com/Kaginari/terraform-provider-docker-utils
 cd terraform-docker-utils
 make install
-````
+```

--- a/docker-utils/data_docker_inspect.go
+++ b/docker-utils/data_docker_inspect.go
@@ -87,11 +87,8 @@ func dataSourceInspectRead(ctx context.Context, data *schema.ResourceData, i int
 	var diags diag.Diagnostics
 	client := i.(*ProviderConfig).DockerClient
 	var container = data.Get("container_name").(string)
-	retContainer, err := client.ContainerInspect(ctx, container)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	res, err := client.ContainerInspect(ctx, retContainer.ID)
+
+	res, err := client.ContainerInspect(ctx, container)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -116,7 +113,7 @@ func dataSourceInspectRead(ctx context.Context, data *schema.ResourceData, i int
 		return diag.FromErr(err)
 	}
 
-	data.SetId(retContainer.ID)
+	data.SetId(res.ID)
 
 	return diags
 }

--- a/docker-utils/data_docker_inspect.go
+++ b/docker-utils/data_docker_inspect.go
@@ -72,6 +72,10 @@ func dataSourceInspect() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"ip_prefixlen": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -132,5 +136,6 @@ func populateNetwork(data *types.NetworkSettings, network string) map[string]int
 		"network_name": network,
 		"ip_address":   data.Networks[network].IPAddress,
 		"gateway":      data.Networks[network].Gateway,
+		"ip_prefixlen": data.Networks[network].IPPrefixLen,
 	}
 }

--- a/docs/data-sources/docker-utils_inspect.md
+++ b/docs/data-sources/docker-utils_inspect.md
@@ -13,11 +13,13 @@ data "docker-utils_inspect" "example" {
 ## Argument Reference
 
 The following arguments are supported:
+
 * `name` - (Required) The name, alias or ID of the container.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
+
 * `id` - The id of the container.
 * `environment` - A List of string represents the env variables in the container.
 * `mounts` - A List of mounts block as documented below.
@@ -26,6 +28,7 @@ In addition to all arguments above, the following attributes are exported:
 ---
 
 A `mounts` block exports the following:
+
 * `source` - The source of the mount. For bind mounts, this is the path to the file or directory on the Docker daemon host.
 * `destination` - the destination takes as its value the path where the file or directory is mounted in the container.
 * `propagation` - The bind-propagation option, if present, changes the bind propagation. May be one of rprivate, private, rshared, shared, rslave, slave.
@@ -33,8 +36,9 @@ A `mounts` block exports the following:
 * `type` - The type of the mount, which can be bind, volume, or tmpfs.
 * `mode` - The mode is a string that represents how the volume is mounted expl: 'RW' - read write .
 
-
 A `networks` block exports the following:
-* `network_name` - The name of the network 
-* `ip_address` - The container's ip address in this network.
+
+* `network_name` - The name of the network.
+* `ip_address` - The container's IP address in this network.
 * `gateway` - The gateway address of the network.
+* `ip_prefixlen` - The mask length of the IP address.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,12 @@
 # Docker-utils Provider
 
-The Docker-utils Provider is used to interact with the many resources supported by Docker but not provided in docker provider. 
-The provider needs to be configured with the proper host before it can be used.
-Use the navigation to the left to read about the available resources.
+The Docker-utils Provider is used to interact with the many resources
+supported by Docker but not provided in docker provider. The provider needs
+to be configured with the proper host before it can be used. Use the
+navigation to the left to read about the available resources.
 
 ## Example Usage
+
 ```hcl
 terraform {
   required_version = ">= 0.13"
@@ -65,11 +67,11 @@ output "logs" {
   value = data.docker-utils_logs.example.logs
 }
 
-# List of container mounts 
+# List of container mounts
 output "container_mounts" {
   value = data.docker-utils_inspect.example.mounts
 }
-# List of container env variables 
+# List of container env variables
 output "container_environment" {
   value = data.docker-utils_inspect.example.environment
 }

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-TERRAFORM_PLUGINS_DIRECTORY=/home/monta/.terraform.d/plugins
+TERRAFORM_PLUGINS_DIRECTORY=${HOME}/.terraform.d/plugins
 
 init:
 	cd


### PR DESCRIPTION
First off - thanks for creating `docker-utils`!!

This PR adds `IPPrefixLen` to the list of exported network attributes. This is useful when you need the container or gateway IP  formatted using CIDR notation i.e. `172.18.0.1/16`.

The change is quite minor and should not cause any breaking changes. 

Please note that the last commit adds some (unrelated) fixes to markdown etc that I did as I came across them.

Please let me know if you would like anything changing/dropped/squashed.


#### Example

```hcl
terraform {
  required_version = ">= 0.13"

  required_providers {
    docker-utils = {
      source  = "Kaginari/docker-utils"
      version = "9.9.9"
    }

  }
}

variable "docker_container_name" {
  default = "kind-control-plane"
}


data "docker-utils_inspect" "example" {
  container_name = var.docker_container_name
}

// List of container networks
output "container_networks" {
  value = data.docker-utils_inspect.example.networks
}

locals {
  ip_addr      = data.docker-utils_inspect.example.networks[0].ip_address
  ip_prefixlen = data.docker-utils_inspect.example.networks[0].ip_prefixlen
  ip_cidr      = format("%s/%d", local.ip_addr, local.ip_prefixlen)
}

output "ip_cidr" {
  value = local.ip_cidr
}

output "container_id" {
  value = data.docker-utils_inspect.example.id
}
```

#### Sample Output

```bash
$ terraform apply

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

container_id = "d5e8768e693f3f44972f6f119116b605a28f5afa495cc5daf518211b4a10b705"
container_networks = tolist([
  {
    "gateway" = "172.18.0.1"
    "ip_address" = "172.18.0.2"
    "ip_prefixlen" = 16
    "network_name" = "kind"
  },
])
ip_cidr = "172.18.0.2/16"
```
